### PR TITLE
Fix mounting package.json in Docker Compose configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,5 +4,5 @@ services:
       context: .
     volumes:
       - "./npm_packages_downloaded:/npm_packages_downloaded"
-      - "./package.json:/home/node/app/package.json"
+      - "./package.json:/home/node/app/package.json:ro"
       - "./script_dependencies.py:/script_dependencies.py"


### PR DESCRIPTION
Fix mounting package.json as a file instead of a directory in docker-compose.yml.

Mount it read-only to avoid container startup errors.

Example error i get:

```
~/Downloads/NPM-Offline-Package-Downloader$ docker compose up
[+] Running 1/1
 ✔ Container npm-offline-package-downloader-download-1  Created                                                                                                                    0.0s 
Attaching to download-1
Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/home/raph/Downloads/NPM-Offline-Package-Downloader/package.json" to rootfs at "/home/node/app/package.json": mount src=/home/raph/Downloads/NPM-Offline-Package-Downloader/package.json, dst=/home/node/app/package.json, dstFd=/proc/thread-self/fd/8, flags=0x5000: not a directory: unknown: Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type

```